### PR TITLE
npm2yarn support

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -1,9 +1,16 @@
 ---
 sidebar_position: 1
 slug: /
+title: Getting Started
 ---
 
-# Getting started
+
+# Solib
+
+Solib is a friendly, easy to use Solana API. All the functionality needed to interact with Solana is baked into Solib, including connecting wallets, signing messages, sending transactions, interacting with Bonafida's name service  and more.
+
+## Getting started
+
 Getting started with Solib is as simple as calling a couple of functions. No
 need to worry about managing clients or state, all of it is handled in the
 background.

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -12,14 +12,8 @@ background.
 
 Instal Solib using the following
 
-### NPM
-```bash
+```bash npm2yarn
 npm install --save @walletconnect/solib
-```
-
-### Yarn
-```bash
-yarn add @walletconnect/solib
 ```
 
 ## Initializing Solib

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -28,11 +28,14 @@ const config = {
           routeBasePath: "/",
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-          'https://github.com/WalletConnect/solib/tree/development/docs'
+          'https://github.com/WalletConnect/solib/tree/development/docs',
+          remarkPlugins: [
+            [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
+          ],
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css')
-        }
+        },
       })
     ]
   ],

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula')
 const config = {
   title: 'Solib',
   tagline: 'Friendly Solana API ',
-  url: 'https://docs.solib.com',
+  url: 'https://solib.dev/',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@docusaurus/core": "2.2.0",
     "@docusaurus/preset-classic": "2.2.0",
+    "@docusaurus/remark-plugin-npm2yarn": "^2.2.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1458,6 +1458,15 @@
     "@types/react" "*"
     prop-types "^15.6.2"
 
+"@docusaurus/remark-plugin-npm2yarn@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/remark-plugin-npm2yarn/-/remark-plugin-npm2yarn-2.2.0.tgz#12d433eda8986c475277dd7fb8624b10c8a976ea"
+  integrity sha512-CFiwzk+0QrlBjkcx4cNV8LQZHgo15aQ3piO0Iao0vGXLc7eupGigDLuE7q3Phc10ELweO+P2gRQTjlBqIQTC+Q==
+  dependencies:
+    npm-to-yarn "^1.0.1"
+    tslib "^2.4.0"
+    unist-util-visit "^2.0.3"
+
 "@docusaurus/theme-classic@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.2.0.tgz#a048bb1bc077dee74b28bec25f4b84b481863742"
@@ -5202,6 +5211,11 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+npm-to-yarn@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-to-yarn/-/npm-to-yarn-1.0.1.tgz#6cdb95114c4ff0be50a7a2381d4d16131a5f52df"
+  integrity sha512-bp8T8oNMfLW+N/fE0itFfSu7RReytwhqNd9skbkfHfzGYC+5CCdzS2HnaXz6JiG4AlK2eA0qlT6NJN1SoFvcWQ==
 
 nprogress@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This update uses npm2yarn to tidy up formatting of code blocks.
Uses the docusaurus tab bar UI instead.

Also adds solib intro.

## Old

<img width="589" alt="Screenshot 2022-10-31 at 16 09 15" src="https://user-images.githubusercontent.com/116099/199041360-b2ba6fd5-b29c-4842-a02b-cf04158b5ee0.png">


## New

<img width="572" alt="Screenshot 2022-10-31 at 16 08 54" src="https://user-images.githubusercontent.com/116099/199041386-a54d247a-4af4-41f2-85c0-34852bd25153.png">
