### PR TITLE
add plausible

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -18,7 +18,7 @@ const config = {
     defaultLocale: 'en',
     locales: ['en']
   },
-
+  scripts: [{src: 'https://plausible.io/js/plausible.js', defer: true, 'data-domain': 'solib.dev'}],
   presets: [
     [
       'classic',


### PR DESCRIPTION
Adds snipped for https://plausible.io/

The goal of Plausible is to understand overall trends in this websites traffic in a privacy-preserving manner, and is not to track individual visitors. Plausbile does not use cookies, does not generate any persistent identifiers and does not collect or store any personal or identifiable data. All of the data is aggregated data only and it has no personal information. All the site measurement is carried out absolutely anonymously. Read more about about [Plausible's data policy](https://plausible.io/data-policy).

Verified that Plausible is receiving the data correctly.  ✅